### PR TITLE
small LESS sintaxis error fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ How use with PostCSS:
 @import 'bower_components/multi-brand-colors/dist/less/index.less';
 
 .div {
-  color: $mbc-twitter;
+  color: @mbc-twitter;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ How use with PostCSS:
 
 ### SASS
 ```sass
-@import 'bower_components/multi-brand-colors/dist/sass/index.sass';
+@import 'bower_components/multi-brand-colors/dist/sass/index.sass'
 
 .div {
-  color: $mbc-twitter;
+  color: $mbc-twitter
 }
 ```
 


### PR DESCRIPTION
in LESS variables are prefixed with `@` not `$`
in SASS no need of closing `;`
