### PR TITLE
remove prefix from generated json file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -93,7 +93,7 @@ gulp.task('minifyCss', function () {
 
 // Render JSON
 gulp.task('json', function () {
-	$.file('index.json', parseJson(template.colors, template.prefix + '-'))
+	$.file('index.json', parseJson(template.colors))
 	.pipe(gulp.dest(DEST + '/json'));
 });
 


### PR DESCRIPTION
in css files there is need to have prefix because everything is global, which is not the case when generating json. so remove prefix from brand color names in json
